### PR TITLE
replace user.id with user.key

### DIFF
--- a/content/src/policies/__id/put.rego
+++ b/content/src/policies/__id/put.rego
@@ -18,6 +18,10 @@ allowed {
 	input.user.key == input.resource.id
 }
 
+allowed {
+	input.user.id == input.resource.id
+}
+
 visible {
 	some index
 	data.roles[user_roles[index]].perms[path].visible

--- a/content/src/policies/__id/put.rego
+++ b/content/src/policies/__id/put.rego
@@ -15,7 +15,7 @@ allowed {
 }
 
 allowed {
-	input.user.id == input.resource.id
+	input.user.key == input.resource.id
 }
 
 visible {


### PR DESCRIPTION
https://github.com/aserto-demo/peoplefinder - is using dir v1 users, so it can evaluate `user.id`
https://github.com/aserto-demo/peoplefinder-acmecorp/pull/29 - will be using the new directory with no ids, so it needs to evaluate `user.key`